### PR TITLE
feat(pixlet): install shell completions; gzip fonts

### DIFF
--- a/Formula/pixlet.rb
+++ b/Formula/pixlet.rb
@@ -22,12 +22,16 @@ class Pixlet < Formula
       system "npm", "run", "build"
     end
 
+    system "go", "generate", "./fonts"
+
     ldflags = %W[
       -s -w
       -X github.com/tronbyt/pixlet/cmd.Version=#{version}
     ]
 
-    system "go", "build", *std_go_args(ldflags: ldflags), "github.com/tronbyt/pixlet"
+    tags = ["gzip_fonts"]
+
+    system "go", "build", *std_go_args(ldflags: ldflags, tags: tags), "github.com/tronbyt/pixlet"
 
     generate_completions_from_executable(bin/"pixlet", "completion")
   end

--- a/Formula/pixlet.rb
+++ b/Formula/pixlet.rb
@@ -28,6 +28,8 @@ class Pixlet < Formula
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "github.com/tronbyt/pixlet"
+
+    generate_completions_from_executable(bin/"pixlet", "completion")
   end
 
   test do


### PR DESCRIPTION
Adds shell completions to the bottle and gzips fonts to shrink the binary by ~6MB